### PR TITLE
feat: add hmr for main process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,149 +1,150 @@
 {
-  "name": "electron-react-typescript",
-  "version": "0.0.7",
-  "description": "",
-  "main": "./dist/main.js",
-  "scripts": {
-    "build-main": "cross-env NODE_ENV=production webpack --config webpack.main.prod.config.js",
-    "build-renderer": "cross-env NODE_ENV=production webpack --config webpack.renderer.prod.config.js",
-    "build": "npm run build-main && npm run build-renderer",
-    "start-renderer-dev": "webpack-dev-server --config webpack.renderer.dev.config.js",
-    "start-main-dev": "webpack --config webpack.main.config.js && electron ./dist/main.js",
-    "start-dev": "cross-env START_HOT=1 npm run start-renderer-dev",
-    "prestart": "npm run build",
-    "start": "electron .",
-    "lint": "eslint --ext=jsx,js,tsx,ts src",
-    "test": "jest '(\\/test\\/(?!e2e/)).*'",
-    "pretest:e2e": "npm run build",
-    "test:e2e": "jest '(\\/test\\/e2e/).*'",
-    "pack": "npm run build && electron-builder --dir",
-    "dist": "npm run build && electron-builder",
-    "postinstall": "electron-builder install-app-deps"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
+    "name": "electron-react-typescript",
+    "version": "0.0.7",
+    "description": "",
+    "main": "./dist/main.js",
+    "scripts": {
+        "build-main": "cross-env NODE_ENV=production webpack --config webpack.main.prod.config.js",
+        "build-renderer": "cross-env NODE_ENV=production webpack --config webpack.renderer.prod.config.js",
+        "build": "npm run build-main && npm run build-renderer",
+        "start-renderer-dev": "webpack-dev-server --config webpack.renderer.dev.config.js",
+        "start-main-dev": "webpack --config webpack.main.dev.config.js --watch",
+        "start-dev": "cross-env START_HOT=1 npm run start-renderer-dev",
+        "prestart": "npm run build",
+        "start": "electron .",
+        "lint": "eslint --ext=jsx,js,tsx,ts src",
+        "test": "jest '(\\/test\\/(?!e2e/)).*'",
+        "pretest:e2e": "npm run build",
+        "test:e2e": "jest '(\\/test\\/e2e/).*'",
+        "pack": "npm run build && electron-builder --dir",
+        "dist": "npm run build && electron-builder",
+        "postinstall": "electron-builder install-app-deps"
+    },
+    "husky": {
+        "hooks": {
+            "pre-commit": "lint-staged"
+        }
+    },
+    "lint-staged": {
+        "{src,test,mocks}/**/*.{json,css,scss,md}": [
+            "prettier --config ./.prettierrc --write"
+        ],
+        "{src,test,mocks}/**/*.{js,ts,tsx}": [
+            "prettier --config ./.prettierrc --write",
+            "eslint --ext=jsx,js,ts,tsx --fix src"
+        ]
+    },
+    "jest": {
+        "transform": {
+            "^.+\\.tsx?$": "ts-jest"
+        },
+        "testRegex": "(/test/.+\\.spec)\\.tsx?$",
+        "moduleFileExtensions": [
+            "ts",
+            "tsx",
+            "js",
+            "json",
+            "node"
+        ],
+        "moduleNameMapper": {
+            "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/mocks/fileMock.js",
+            "\\.(s?css|sass)$": "<rootDir>/mocks/styleMock.js"
+        }
+    },
+    "build": {
+        "productName": "ProductName",
+        "appId": "org.your.productname",
+        "mac": {
+            "category": "your.app.category.type"
+        },
+        "directories": {
+            "output": "release"
+        },
+        "files": [
+            "dist/",
+            "node_modules/",
+            "package.json"
+        ],
+        "linux": {
+            "target": "deb"
+        },
+        "win": {
+            "target": "nsis"
+        }
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com:Robinfr/electron-react-typescript.git"
+    },
+    "author": {
+        "name": "Your name",
+        "email": "Your email"
+    },
+    "license": "SEE LICENSE",
+    "bugs": {
+        "url": "https://github.com/Robinfr/electron-react-typescript/issues"
+    },
+    "homepage": "https://github.com/Robinfr/electron-react-typescript",
+    "devDependencies": {
+        "@babel/core": "^7.4.5",
+        "@babel/plugin-proposal-class-properties": "^7.4.4",
+        "@babel/polyfill": "^7.4.4",
+        "@babel/preset-env": "^7.4.5",
+        "@babel/preset-react": "^7.0.0",
+        "@babel/preset-typescript": "^7.3.3",
+        "@hot-loader/react-dom": "^16.8.6",
+        "@types/electron-devtools-installer": "^2.2.0",
+        "@types/jest": "^24.0.13",
+        "@types/react": "^16.8.18",
+        "@types/react-dom": "^16.8.4",
+        "@types/react-redux": "^7.0.9",
+        "@types/react-test-renderer": "^16.8.1",
+        "@types/webdriverio": "^4.8.7",
+        "@types/webpack-env": "^1.13.3",
+        "@typescript-eslint/eslint-plugin": "^2.4.0",
+        "@typescript-eslint/parser": "^2.4.0",
+        "babel-loader": "^8.0.6",
+        "cross-env": "^5.1.3",
+        "css-loader": "^2.1.1",
+        "electron": "^3.1.9",
+        "electron-builder": "^22.3.2",
+        "electron-devtools-installer": "^2.2.4",
+        "eslint": "^6.5.1",
+        "eslint-config-airbnb": "^18.0.1",
+        "eslint-config-prettier": "^6.4.0",
+        "eslint-plugin-import": "^2.18.2",
+        "eslint-plugin-jsx-a11y": "^6.2.3",
+        "eslint-plugin-prettier": "^3.1.1",
+        "eslint-plugin-react": "^7.16.0",
+        "eslint-plugin-react-hooks": "^1.7.0",
+        "file-loader": "^3.0.1",
+        "fork-ts-checker-webpack-plugin": "^1.3.4",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^4.2.1",
+        "image-webpack-loader": "^4.6.0",
+        "jest": "^24.8.0",
+        "lint-staged": "^10.0.7",
+        "node-sass": "^4.12.0",
+        "nodemon-webpack-plugin": "^4.3.1",
+        "prettier": "^1.18.2",
+        "react-hot-loader": "^4.8.8",
+        "react-test-renderer": "^16.8.6",
+        "redux-devtools-extension": "^2.13.5",
+        "sass-loader": "^7.1.0",
+        "source-map-loader": "^0.2.4",
+        "spectron": "^5.0.0",
+        "style-loader": "^0.23.1",
+        "ts-jest": "^24.0.2",
+        "typescript": "^3.4.5",
+        "webpack": "^4.32.2",
+        "webpack-cli": "^3.3.2",
+        "webpack-dev-server": "^3.4.1",
+        "webpack-merge": "^4.2.1"
+    },
+    "dependencies": {
+        "react": "^16.8.6",
+        "react-dom": "^16.8.6",
+        "react-redux": "^7.0.3",
+        "redux": "^4.0.1"
     }
-  },
-  "lint-staged": {
-    "{src,test,mocks}/**/*.{json,css,scss,md}": [
-      "prettier --config ./.prettierrc --write"
-    ],
-    "{src,test,mocks}/**/*.{js,ts,tsx}": [
-      "prettier --config ./.prettierrc --write",
-      "eslint --ext=jsx,js,ts,tsx --fix src"
-    ]
-  },
-  "jest": {
-    "transform": {
-      "^.+\\.tsx?$": "ts-jest"
-    },
-    "testRegex": "(/test/.+\\.spec)\\.tsx?$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "json",
-      "node"
-    ],
-    "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/mocks/fileMock.js",
-      "\\.(s?css|sass)$": "<rootDir>/mocks/styleMock.js"
-    }
-  },
-  "build": {
-    "productName": "ProductName",
-    "appId": "org.your.productname",
-    "mac": {
-      "category": "your.app.category.type"
-    },
-    "directories": {
-      "output": "release"
-    },
-    "files": [
-      "dist/",
-      "node_modules/",
-      "package.json"
-    ],
-    "linux": {
-      "target": "deb"
-    },
-    "win": {
-      "target": "nsis"
-    }
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+ssh://git@github.com:Robinfr/electron-react-typescript.git"
-  },
-  "author": {
-    "name": "Your name",
-    "email": "Your email"
-  },
-  "license": "SEE LICENSE",
-  "bugs": {
-    "url": "https://github.com/Robinfr/electron-react-typescript/issues"
-  },
-  "homepage": "https://github.com/Robinfr/electron-react-typescript",
-  "devDependencies": {
-    "@babel/core": "^7.4.5",
-    "@babel/plugin-proposal-class-properties": "^7.4.4",
-    "@babel/polyfill": "^7.4.4",
-    "@babel/preset-env": "^7.4.5",
-    "@babel/preset-react": "^7.0.0",
-    "@babel/preset-typescript": "^7.3.3",
-    "@hot-loader/react-dom": "^16.8.6",
-    "@types/electron-devtools-installer": "^2.2.0",
-    "@types/jest": "^24.0.13",
-    "@types/react": "^16.8.18",
-    "@types/react-dom": "^16.8.4",
-    "@types/react-redux": "^7.0.9",
-    "@types/react-test-renderer": "^16.8.1",
-    "@types/webdriverio": "^4.8.7",
-    "@types/webpack-env": "^1.13.3",
-    "@typescript-eslint/eslint-plugin": "^2.4.0",
-    "@typescript-eslint/parser": "^2.4.0",
-    "babel-loader": "^8.0.6",
-    "cross-env": "^5.1.3",
-    "css-loader": "^2.1.1",
-    "electron": "^3.1.9",
-    "electron-builder": "^22.3.2",
-    "electron-devtools-installer": "^2.2.4",
-    "eslint": "^6.5.1",
-    "eslint-config-airbnb": "^18.0.1",
-    "eslint-config-prettier": "^6.4.0",
-    "eslint-plugin-import": "^2.18.2",
-    "eslint-plugin-jsx-a11y": "^6.2.3",
-    "eslint-plugin-prettier": "^3.1.1",
-    "eslint-plugin-react": "^7.16.0",
-    "eslint-plugin-react-hooks": "^1.7.0",
-    "file-loader": "^3.0.1",
-    "fork-ts-checker-webpack-plugin": "^1.3.4",
-    "html-webpack-plugin": "^3.2.0",
-    "husky": "^4.2.1",
-    "image-webpack-loader": "^4.6.0",
-    "jest": "^24.8.0",
-    "lint-staged": "^10.0.7",
-    "node-sass": "^4.12.0",
-    "prettier": "^1.18.2",
-    "react-hot-loader": "^4.8.8",
-    "react-test-renderer": "^16.8.6",
-    "redux-devtools-extension": "^2.13.5",
-    "sass-loader": "^7.1.0",
-    "source-map-loader": "^0.2.4",
-    "spectron": "^5.0.0",
-    "style-loader": "^0.23.1",
-    "ts-jest": "^24.0.2",
-    "typescript": "^3.4.5",
-    "webpack": "^4.32.2",
-    "webpack-cli": "^3.3.2",
-    "webpack-dev-server": "^3.4.1",
-    "webpack-merge": "^4.2.1"
-  },
-  "dependencies": {
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
-    "react-redux": "^7.0.3",
-    "redux": "^4.0.1"
-  }
 }

--- a/webpack.main.dev.config.js
+++ b/webpack.main.dev.config.js
@@ -1,0 +1,10 @@
+const merge = require('webpack-merge');
+const NodemonPlugin = require('nodemon-webpack-plugin')
+
+const baseConfig = require('./webpack.main.config');
+
+module.exports = merge.smart(baseConfig, {
+  plugins:[new NodemonPlugin({
+    exec: "electron ./dist/main.js"
+  })]
+});


### PR DESCRIPTION
This enables hmr for electron in development.

Basically it uses a combination of webpack in watch mode with nodemon and it restarts electron after every change event emitted by webpack.